### PR TITLE
Separate role-specific methods into their own traits

### DIFF
--- a/winit-core/src/event_loop/mod.rs
+++ b/winit-core/src/event_loop/mod.rs
@@ -5,7 +5,7 @@ use raw_window_handle_05::HasRawDisplayHandle as HasRawDisplayHandle05;
 
 use crate::application::Application;
 use crate::monitor::{Monitor, MonitorId};
-use crate::window::{Window, WindowAttributes, WindowId};
+use crate::window::{Surface, WindowAttributes, WindowId};
 
 use self::proxy::EventLoopProxy;
 
@@ -37,9 +37,9 @@ pub trait EventLoopHandle: HasDisplayHandle {
 
     fn num_windows(&self) -> usize;
 
-    fn get_window(&self, window_id: WindowId) -> Option<&dyn Window>;
+    fn get_window(&self, window_id: WindowId) -> Option<&dyn Surface>;
 
-    fn get_window_mut(&mut self, window_id: WindowId) -> Option<&mut dyn Window>;
+    fn get_window_mut(&mut self, window_id: WindowId) -> Option<&mut dyn Surface>;
 
     fn get_monitor(&self, monitor_id: MonitorId) -> Option<&dyn Monitor>;
 

--- a/winit-core/src/event_loop/mod.rs
+++ b/winit-core/src/event_loop/mod.rs
@@ -5,7 +5,7 @@ use raw_window_handle_05::HasRawDisplayHandle as HasRawDisplayHandle05;
 
 use crate::application::Application;
 use crate::monitor::{Monitor, MonitorId};
-use crate::window::{Surface, WindowAttributes, WindowId};
+use crate::window::{PopupAttributes, Surface, WindowAttributes, WindowId};
 
 use self::proxy::EventLoopProxy;
 
@@ -33,7 +33,10 @@ pub trait EventLoopHandle: HasDisplayHandle {
     fn proxy(&self) -> Arc<dyn EventLoopProxy>;
 
     /// Request to create a window.
-    fn create_window(&mut self, attributes: &WindowAttributes) -> Result<(), ()>;
+    fn create_toplevel(&mut self, attributes: &WindowAttributes) -> Result<(), ()>;
+
+    /// Requests to create a popup.
+    // fn create_popup(&mut self, parent: WindowId, attributes: &PopupAttributes) -> Result<(), ()>;
 
     fn num_windows(&self) -> usize;
 

--- a/winit-core/src/event_loop/mod.rs
+++ b/winit-core/src/event_loop/mod.rs
@@ -36,7 +36,7 @@ pub trait EventLoopHandle: HasDisplayHandle {
     fn create_toplevel(&mut self, attributes: &WindowAttributes) -> Result<(), ()>;
 
     /// Requests to create a popup.
-    // fn create_popup(&mut self, parent: WindowId, attributes: &PopupAttributes) -> Result<(), ()>;
+    fn create_popup(&mut self, parent: WindowId, attributes: &PopupAttributes) -> Result<(), ()>;
 
     fn num_windows(&self) -> usize;
 

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -61,7 +61,7 @@ pub trait Toplevel: Surface {
 
 /// API for popups.
 pub trait Popup: Surface {
-    fn set_position(&mut self, position: PhysicalPosition<u32>);
+    // fn set_position(&mut self, position: PhysicalPosition<u32>);
 }
 
 /// Attributes to use when creating a window.

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -31,6 +31,8 @@ pub trait Surface: HasWindowHandle + HasRawWindowHandle05 {
 
     fn inner_size(&self) -> PhysicalSize<u32>;
 
+    fn create_subview(&self, attrs: WindowAttributes) -> Box<dyn Subview>;
+
     /// Downcasts this surface to its specific type.
     fn role(&self) -> WindowRole;
     /// Downcasts this surface to its specific type. Returns a mutable reference.

--- a/winit-wayland/examples/window.rs
+++ b/winit-wayland/examples/window.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use winit_core::application::{Application, ApplicationWindow, StartCause};
 use winit_core::dpi::PhysicalSize;
 use winit_core::event_loop::{EventLoopHandle, EventLoopRequests};
-use winit_core::window::WindowId;
+use winit_core::window::{Toplevel, WindowId, WindowRole};
 use winit_wayland::event_loop::EventLoop;
 use winit_wayland::MyCoolTrait;
 
@@ -89,9 +89,11 @@ impl ApplicationWindow for State {
             _ => return,
         };
 
-        if let Some(monitor_id) = window.current_monitor() {
-            let monitor = loop_handle.get_monitor(monitor_id).unwrap();
-            println!("Current monitor name {:?}", monitor.name());
+        if let WindowRole::Toplevel(toplevel) = window.role() {
+            if let Some(monitor_id) = toplevel.current_monitor() {
+                let monitor = loop_handle.get_monitor(monitor_id).unwrap();
+                println!("Current monitor name {:?}", monitor.name());
+            }
         }
 
         let size = window.inner_size();

--- a/winit-wayland/examples/window.rs
+++ b/winit-wayland/examples/window.rs
@@ -11,6 +11,7 @@ use winit_wayland::MyCoolTrait;
 use softbuffer::{Context, Surface};
 
 const DARK_GRAY: u32 = 0xFF181818;
+const ORANGE: u32 = 0xFF_FF8000;
 
 pub struct State {
     context: Context,
@@ -39,7 +40,7 @@ impl Application for State {
 
     fn new_events(&mut self, loop_handle: &mut dyn EventLoopHandle, start_cause: StartCause) {
         println!("Start cause {start_cause:?}");
-        let _ = loop_handle.create_window(&Default::default());
+        let _ = loop_handle.create_toplevel(&Default::default());
     }
 
     fn about_to_wait(&mut self, _: &mut dyn EventLoopHandle) {
@@ -89,19 +90,33 @@ impl ApplicationWindow for State {
             _ => return,
         };
 
-        if let WindowRole::Toplevel(toplevel) = window.role() {
-            if let Some(monitor_id) = toplevel.current_monitor() {
-                let monitor = loop_handle.get_monitor(monitor_id).unwrap();
-                println!("Current monitor name {:?}", monitor.name());
-            }
-        }
+        match window.role() {
+            WindowRole::Toplevel(toplevel) => {
+                if let Some(monitor_id) = toplevel.current_monitor() {
+                    let monitor = loop_handle.get_monitor(monitor_id).unwrap();
+                    println!("Current monitor name {:?}", monitor.name());
+                }
 
-        let size = window.inner_size();
-        let _ = surface
-            .resize(NonZeroU32::new(size.width).unwrap(), NonZeroU32::new(size.height).unwrap());
-        let mut buffer = surface.buffer_mut().unwrap();
-        buffer.fill(DARK_GRAY);
-        buffer.present().unwrap();
+                let size = window.inner_size();
+                let _ = surface.resize(
+                    NonZeroU32::new(size.width).unwrap(),
+                    NonZeroU32::new(size.height).unwrap(),
+                );
+                let mut buffer = surface.buffer_mut().unwrap();
+                buffer.fill(DARK_GRAY);
+                buffer.present().unwrap();
+            },
+            WindowRole::Popup(popup) => {
+                let size = window.inner_size();
+                let _ = surface.resize(
+                    NonZeroU32::new(size.width).unwrap(),
+                    NonZeroU32::new(size.height).unwrap(),
+                );
+                let mut buffer = surface.buffer_mut().unwrap();
+                buffer.fill(ORANGE);
+                buffer.present().unwrap();
+            },
+        }
     }
 
     fn destroyed(&mut self, loop_handle: &mut dyn EventLoopHandle, _: WindowId) {

--- a/winit-wayland/src/event_loop.rs
+++ b/winit-wayland/src/event_loop.rs
@@ -20,7 +20,7 @@ use sctk::seat::{Capability as SeatCapability, SeatHandler, SeatState};
 use winit_core::application::Application;
 use winit_core::event_loop::proxy::EventLoopProxy as CoreEventLoopProxy;
 use winit_core::event_loop::{EventLoopHandle, EventLoopRequests};
-use winit_core::window::{Window as CoreWindow, WindowId};
+use winit_core::window::{Surface as CoreSurface, WindowId};
 
 use crate::state::WinitState;
 use crate::MyCoolTrait;

--- a/winit-wayland/src/event_loop.rs
+++ b/winit-wayland/src/event_loop.rs
@@ -93,7 +93,7 @@ impl<T: Application + 'static> EventLoopRequests<T> for EventLoop<T> {
             let user = self.state.user.as_mut().unwrap();
 
             for (window_id, window) in &mut winit.windows {
-                if mem::take(&mut window.redraw) {
+                if window.take_redraw() {
                     redraw.push(*window_id);
                 }
             }

--- a/winit-wayland/src/lib.rs
+++ b/winit-wayland/src/lib.rs
@@ -14,6 +14,8 @@ pub mod event_loop;
 pub mod monitor;
 pub mod state;
 pub mod toplevel;
+pub mod popup;
+pub mod window;
 
 /// Get the WindowId out of the surface.
 #[inline]

--- a/winit-wayland/src/lib.rs
+++ b/winit-wayland/src/lib.rs
@@ -13,7 +13,7 @@ use winit_core::window::WindowId;
 pub mod event_loop;
 pub mod monitor;
 pub mod state;
-pub mod window;
+pub mod toplevel;
 
 /// Get the WindowId out of the surface.
 #[inline]

--- a/winit-wayland/src/popup.rs
+++ b/winit-wayland/src/popup.rs
@@ -1,0 +1,201 @@
+use std::{marker::PhantomData, ops::Deref, sync::Arc};
+
+use raw_window_handle::{HandleError, HasWindowHandle, WaylandWindowHandle, WindowHandle};
+use raw_window_handle_05::HasRawWindowHandle as HasRawWindowHandle05;
+use sctk::{compositor::CompositorState, shell::{self, xdg::{popup::{PopupConfigure, PopupHandler, Popup as XdgPopup}, XdgPositioner, XdgSurface}}};
+use wayland_client::Dispatch;
+use wayland_protocols::{wp::{fractional_scale::v1::client::wp_fractional_scale_v1::WpFractionalScaleV1, viewporter::client::wp_viewport::WpViewport}, xdg::shell::client::xdg_positioner};
+use winit_core::{application::Application, dpi::Size, window::{AnchorDirection, AnchorHints, PopupAttributes, Surface, Theme, WindowAttributes, WindowId}};
+
+use crate::{event_loop::RuntimeState, state::WinitState};
+
+pub struct Popup<T: Application + 'static> {
+    /// The last received configure.
+    pub last_configure: Option<PopupConfigure>,
+
+    pub viewport: Option<WpViewport>,
+    fractional_scale: Option<WpFractionalScaleV1>,
+
+    /// The scale factor of the window.
+    pub scale_factor: f64,
+
+    /// Initial window size provided by the user. Removed on the first
+    /// configure.
+    initial_size: Option<Size>,
+
+    compositor: Arc<CompositorState>,
+
+    /// Whether the window is transparent.
+    transparent: bool,
+
+    pub redraw: bool,
+
+    // Note, should be the last since it drops the surface.
+    pub popup: XdgPopup,
+
+    _phantom_tparam_do_not_use: PhantomData<T>
+}
+
+impl<T: Application + 'static> Popup<T> {
+    pub fn new(winit: &mut WinitState<T>, parent: &impl XdgSurface, attributes: &PopupAttributes) -> Self {
+        let compositor = winit.compositor.clone();
+        let surface = compositor.create_surface(&winit.queue_handle);
+
+        let positioner = {
+            let positioner = XdgPositioner::new(&winit.xdg_shell).unwrap();
+
+            let anchor_top_left = attributes.anchor_rect().0.to_physical::<i32>(1.0);
+            let anchor_size = attributes.anchor_rect().1.to_physical::<i32>(1.0);
+            positioner.set_anchor_rect(anchor_top_left.x, anchor_top_left.y, anchor_size.width, anchor_size.height);
+
+            let inner_size = attributes.inner_size().to_physical::<i32>(1.0);
+            positioner.set_size(inner_size.width, inner_size.height);
+
+            positioner.set_gravity(to_xdg_positioner_gravity(attributes.surface_anchor()));
+            positioner.set_anchor(to_xdg_positioner_anchor(attributes.rect_anchor()));
+
+            positioner.set_constraint_adjustment(to_xdg_constraints(attributes.anchor_hints()).bits());
+
+            positioner
+        };
+
+        let popup = XdgPopup::new(parent.xdg_surface(), &positioner.deref(), &winit.queue_handle, &*winit.compositor, &winit.xdg_shell).unwrap();
+        let size = attributes.inner_size();
+
+        Self {
+            last_configure: None,
+            viewport: None,
+            fractional_scale: None,
+            scale_factor: 1.0,
+            initial_size: Some(size),
+            compositor,
+            transparent: true,
+            redraw: false,
+            popup,
+            _phantom_tparam_do_not_use: PhantomData,
+        }
+    }
+
+    pub fn configured(&self) -> bool {
+        self.last_configure.is_some()
+    }
+}
+
+impl<T: Application + 'static> Surface for Popup<T> {
+    fn id(&self) -> WindowId {
+        todo!()
+    }
+
+    fn scale_factor(&self) -> f64 {
+        todo!()
+    }
+
+    fn request_redraw(&mut self) {
+        todo!()
+    }
+
+    fn inner_size(&self) -> winit_core::dpi::PhysicalSize<u32> {
+        todo!()
+    }
+
+    fn role(&self) -> winit_core::window::WindowRole {
+        todo!()
+    }
+
+    fn role_mut(&mut self) -> winit_core::window::WindowRoleMut {
+        todo!()
+    }
+}
+
+impl<T: Application + 'static> HasWindowHandle for Popup<T> {
+    fn window_handle(&self) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
+        todo!()
+    }
+}
+
+unsafe impl<T: Application + 'static> HasRawWindowHandle05 for Popup<T> {
+    fn raw_window_handle(&self) -> raw_window_handle_05::RawWindowHandle {
+        todo!()
+    }
+}
+
+impl<T: Application + 'static> PopupHandler for RuntimeState<T> {
+    fn configure(
+        &mut self,
+        _: &wayland_client::Connection,
+        queue_handle: &wayland_client::QueueHandle<Self>,
+        popup: &XdgPopup,
+        configure: PopupConfigure,
+    ) {
+        let winit = &mut self.winit;
+        let window_id = crate::make_wid(popup.wl_surface());
+    }
+
+    fn done(&mut self, conn: &wayland_client::Connection, qh: &wayland_client::QueueHandle<Self>, popup: &XdgPopup) {
+        // nothing
+    }
+}
+
+impl<T: Application + 'static, U> Dispatch<xdg_positioner::XdgPositioner, U>  for RuntimeState<T> {
+    fn event(
+        state: &mut Self,
+        proxy: &xdg_positioner::XdgPositioner,
+        event: <xdg_positioner::XdgPositioner as wayland_client::Proxy>::Event,
+        data: &U,
+        conn: &wayland_client::Connection,
+        qhandle: &wayland_client::QueueHandle<Self>,
+    ) {
+        // nothing, positioners do not generate events
+    }
+}
+
+sctk::delegate_xdg_popup!(@<T: Application + 'static> RuntimeState<T>);
+
+fn to_xdg_positioner_anchor(dir: AnchorDirection) -> xdg_positioner::Anchor {
+    match dir {
+        AnchorDirection::Center => xdg_positioner::Anchor::None,
+        AnchorDirection::North => xdg_positioner::Anchor::Top,
+        AnchorDirection::Northeast => xdg_positioner::Anchor::TopRight,
+        AnchorDirection::East => xdg_positioner::Anchor::Right,
+        AnchorDirection::Southeast => xdg_positioner::Anchor::BottomRight,
+        AnchorDirection::South => xdg_positioner::Anchor::Bottom,
+        AnchorDirection::Southwest => xdg_positioner::Anchor::BottomLeft,
+        AnchorDirection::West => xdg_positioner::Anchor::Left,
+        AnchorDirection::Northwest => xdg_positioner::Anchor::TopLeft,
+    }
+}
+fn to_xdg_positioner_gravity(dir: AnchorDirection) -> xdg_positioner::Gravity {
+    match dir {
+        AnchorDirection::Center => xdg_positioner::Gravity::None,
+        AnchorDirection::North => xdg_positioner::Gravity::Top,
+        AnchorDirection::Northeast => xdg_positioner::Gravity::TopRight,
+        AnchorDirection::East => xdg_positioner::Gravity::Right,
+        AnchorDirection::Southeast => xdg_positioner::Gravity::BottomRight,
+        AnchorDirection::South => xdg_positioner::Gravity::Bottom,
+        AnchorDirection::Southwest => xdg_positioner::Gravity::BottomLeft,
+        AnchorDirection::West => xdg_positioner::Gravity::Left,
+        AnchorDirection::Northwest => xdg_positioner::Gravity::TopLeft,
+    }
+}
+fn to_xdg_constraints(flags: AnchorHints) -> xdg_positioner::ConstraintAdjustment {
+    let mut res = xdg_positioner::ConstraintAdjustment::None;
+    if flags.contains(AnchorHints::SLIDE_X) {
+        res |= xdg_positioner::ConstraintAdjustment::SlideX;
+    }
+    if flags.contains(AnchorHints::SLIDE_Y) {
+        res |= xdg_positioner::ConstraintAdjustment::SlideY;
+    }
+    if flags.contains(AnchorHints::FLIP_X) {
+        res |= xdg_positioner::ConstraintAdjustment::FlipX;
+    }
+    if flags.contains(AnchorHints::FLIP_Y) {
+        res |= xdg_positioner::ConstraintAdjustment::FlipY;
+    }
+    if flags.contains(AnchorHints::RESIZE_X) {
+        res |= xdg_positioner::ConstraintAdjustment::ResizeX;
+    }
+    if flags.contains(AnchorHints::RESIZE_Y) {
+        res |= xdg_positioner::ConstraintAdjustment::ResizeY;
+    }
+    res
+}

--- a/winit-wayland/src/popup.rs
+++ b/winit-wayland/src/popup.rs
@@ -1,13 +1,37 @@
-use std::{marker::PhantomData, ops::Deref, sync::Arc};
+use std::{marker::PhantomData, ops::Deref, ptr::NonNull, sync::Arc};
 
-use raw_window_handle::{HandleError, HasWindowHandle, WaylandWindowHandle, WindowHandle};
+use raw_window_handle::{
+    HandleError, HasWindowHandle, RawWindowHandle, WaylandWindowHandle, WindowHandle,
+};
 use raw_window_handle_05::HasRawWindowHandle as HasRawWindowHandle05;
-use sctk::{compositor::CompositorState, shell::{self, xdg::{popup::{PopupConfigure, PopupHandler, Popup as XdgPopup}, XdgPositioner, XdgSurface}}};
-use wayland_client::Dispatch;
-use wayland_protocols::{wp::{fractional_scale::v1::client::wp_fractional_scale_v1::WpFractionalScaleV1, viewporter::client::wp_viewport::WpViewport}, xdg::shell::client::xdg_positioner};
-use winit_core::{application::Application, dpi::Size, window::{AnchorDirection, AnchorHints, PopupAttributes, Surface, Theme, WindowAttributes, WindowId}};
+use sctk::{
+    compositor::CompositorState,
+    shell::{
+        self,
+        xdg::{
+            popup::{Popup as XdgPopup, PopupConfigure, PopupHandler},
+            XdgPositioner, XdgSurface,
+        },
+    },
+};
+use wayland_client::{Dispatch, Proxy};
+use wayland_protocols::{
+    wp::{
+        fractional_scale::v1::client::wp_fractional_scale_v1::WpFractionalScaleV1,
+        viewporter::client::wp_viewport::WpViewport,
+    },
+    xdg::shell::client::xdg_positioner,
+};
+use winit_core::{
+    application::Application,
+    dpi::{LogicalSize, PhysicalSize, Size},
+    window::{
+        AnchorDirection, AnchorHints, Popup as WinitPopup, PopupAttributes,
+        Surface as WinitSurface, Theme, WindowAttributes, WindowId, WindowRole, WindowRoleMut,
+    },
+};
 
-use crate::{event_loop::RuntimeState, state::WinitState};
+use crate::{event_loop::RuntimeState, state::WinitState, window::Window};
 
 pub struct Popup<T: Application + 'static> {
     /// The last received configure.
@@ -18,6 +42,9 @@ pub struct Popup<T: Application + 'static> {
 
     /// The scale factor of the window.
     pub scale_factor: f64,
+
+    /// The inner size of the window, as in without client side decorations.
+    size: LogicalSize<u32>,
 
     /// Initial window size provided by the user. Removed on the first
     /// configure.
@@ -33,11 +60,17 @@ pub struct Popup<T: Application + 'static> {
     // Note, should be the last since it drops the surface.
     pub popup: XdgPopup,
 
-    _phantom_tparam_do_not_use: PhantomData<T>
+    _phantom_tparam_do_not_use: PhantomData<T>,
 }
 
 impl<T: Application + 'static> Popup<T> {
-    pub fn new(winit: &mut WinitState<T>, parent: &impl XdgSurface, attributes: &PopupAttributes) -> Self {
+    pub fn new(
+        winit: &mut WinitState<T>,
+        parent: WindowId,
+        attributes: &PopupAttributes,
+    ) -> Result<Self, ()> {
+        let parent = winit.windows.get(&parent).ok_or(())?;
+
         let compositor = winit.compositor.clone();
         let surface = compositor.create_surface(&winit.queue_handle);
 
@@ -46,7 +79,12 @@ impl<T: Application + 'static> Popup<T> {
 
             let anchor_top_left = attributes.anchor_rect().0.to_physical::<i32>(1.0);
             let anchor_size = attributes.anchor_rect().1.to_physical::<i32>(1.0);
-            positioner.set_anchor_rect(anchor_top_left.x, anchor_top_left.y, anchor_size.width, anchor_size.height);
+            positioner.set_anchor_rect(
+                anchor_top_left.x,
+                anchor_top_left.y,
+                anchor_size.width,
+                anchor_size.height,
+            );
 
             let inner_size = attributes.inner_size().to_physical::<i32>(1.0);
             positioner.set_size(inner_size.width, inner_size.height);
@@ -54,26 +92,35 @@ impl<T: Application + 'static> Popup<T> {
             positioner.set_gravity(to_xdg_positioner_gravity(attributes.surface_anchor()));
             positioner.set_anchor(to_xdg_positioner_anchor(attributes.rect_anchor()));
 
-            positioner.set_constraint_adjustment(to_xdg_constraints(attributes.anchor_hints()).bits());
+            positioner
+                .set_constraint_adjustment(to_xdg_constraints(attributes.anchor_hints()).bits());
 
             positioner
         };
 
-        let popup = XdgPopup::new(parent.xdg_surface(), &positioner.deref(), &winit.queue_handle, &*winit.compositor, &winit.xdg_shell).unwrap();
+        let popup = XdgPopup::new(
+            parent.xdg_surface(),
+            &positioner.deref(),
+            &winit.queue_handle,
+            &*winit.compositor,
+            &winit.xdg_shell,
+        )
+        .unwrap();
         let size = attributes.inner_size();
 
-        Self {
+        Ok(Self {
             last_configure: None,
             viewport: None,
             fractional_scale: None,
             scale_factor: 1.0,
+            size: size.to_logical(1.0),
             initial_size: Some(size),
             compositor,
             transparent: true,
             redraw: false,
             popup,
             _phantom_tparam_do_not_use: PhantomData,
-        }
+        })
     }
 
     pub fn configured(&self) -> bool {
@@ -81,41 +128,54 @@ impl<T: Application + 'static> Popup<T> {
     }
 }
 
-impl<T: Application + 'static> Surface for Popup<T> {
+impl<T: Application + 'static> WinitSurface for Popup<T> {
     fn id(&self) -> WindowId {
-        todo!()
+        crate::make_wid(self.popup.wl_surface())
     }
 
     fn scale_factor(&self) -> f64 {
-        todo!()
+        self.scale_factor
     }
 
     fn request_redraw(&mut self) {
-        todo!()
+        self.redraw = true;
     }
 
     fn inner_size(&self) -> winit_core::dpi::PhysicalSize<u32> {
-        todo!()
+        crate::logical_to_physical_rounded(self.size, self.scale_factor)
     }
 
-    fn role(&self) -> winit_core::window::WindowRole {
-        todo!()
+    fn role(&self) -> WindowRole<'_> {
+        WindowRole::Popup(self)
     }
 
-    fn role_mut(&mut self) -> winit_core::window::WindowRoleMut {
-        todo!()
+    fn role_mut(&mut self) -> WindowRoleMut {
+        WindowRoleMut::Popup(self)
     }
 }
 
+impl<T: Application + 'static> WinitPopup for Popup<T> {}
+
 impl<T: Application + 'static> HasWindowHandle for Popup<T> {
-    fn window_handle(&self) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
-        todo!()
+    fn window_handle(
+        &self,
+    ) -> Result<raw_window_handle::WindowHandle<'_>, raw_window_handle::HandleError> {
+        let ptr = self.popup.wl_surface().id().as_ptr();
+        let handle = WaylandWindowHandle::new({
+            NonNull::new(ptr as *mut _).expect("wl_surface should never be null")
+        });
+
+        unsafe { Ok(WindowHandle::borrow_raw(handle.into())) }
     }
 }
 
 unsafe impl<T: Application + 'static> HasRawWindowHandle05 for Popup<T> {
     fn raw_window_handle(&self) -> raw_window_handle_05::RawWindowHandle {
-        todo!()
+        let ptr = self.popup.wl_surface().id().as_ptr();
+        let mut window_handle = raw_window_handle_05::WaylandWindowHandle::empty();
+        window_handle.surface = ptr as *mut _;
+
+        raw_window_handle_05::RawWindowHandle::Wayland(window_handle)
     }
 }
 
@@ -129,14 +189,51 @@ impl<T: Application + 'static> PopupHandler for RuntimeState<T> {
     ) {
         let winit = &mut self.winit;
         let window_id = crate::make_wid(popup.wl_surface());
+        let popup = match winit.windows.get_mut(&window_id) {
+            Some(Window::Popup(window)) => window,
+            _ => return,
+        };
+
+        let scale_factor = popup.scale_factor;
+
+        if let Some(initial_size) = popup.initial_size.take() {
+            popup.size = initial_size.to_logical(scale_factor);
+        }
+
+        let user = self.user.as_mut().unwrap();
+        let new_size = LogicalSize::<u32>::new(configure.width as u32, configure.height as u32);
+        let initial_configure = popup.last_configure.is_none();
+
+        if initial_configure {
+            user.created(winit, window_id);
+            user.scale_factor_changed(winit, window_id, scale_factor);
+        }
+
+        user.resized(winit, window_id, crate::logical_to_physical_rounded(new_size, scale_factor));
+
+        if initial_configure {
+            user.redraw_requested(winit, window_id);
+        }
     }
 
-    fn done(&mut self, conn: &wayland_client::Connection, qh: &wayland_client::QueueHandle<Self>, popup: &XdgPopup) {
-        // nothing
+    fn done(
+        &mut self,
+        _: &wayland_client::Connection,
+        qh: &wayland_client::QueueHandle<Self>,
+        popup: &XdgPopup,
+    ) {
+        let winit = &mut self.winit;
+        let window_id = crate::make_wid(popup.wl_surface());
+        let popup = match winit.windows.get_mut(&window_id) {
+            Some(Window::Popup(window)) => window,
+            _ => return,
+        };
+
+        // todo: figure out what the hell to do here
     }
 }
 
-impl<T: Application + 'static, U> Dispatch<xdg_positioner::XdgPositioner, U>  for RuntimeState<T> {
+impl<T: Application + 'static, U> Dispatch<xdg_positioner::XdgPositioner, U> for RuntimeState<T> {
     fn event(
         state: &mut Self,
         proxy: &xdg_positioner::XdgPositioner,
@@ -148,8 +245,6 @@ impl<T: Application + 'static, U> Dispatch<xdg_positioner::XdgPositioner, U>  fo
         // nothing, positioners do not generate events
     }
 }
-
-sctk::delegate_xdg_popup!(@<T: Application + 'static> RuntimeState<T>);
 
 fn to_xdg_positioner_anchor(dir: AnchorDirection) -> xdg_positioner::Anchor {
     match dir {

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -28,8 +28,8 @@ use sctk::subcompositor::SubcompositorState;
 use winit_core::application::Application;
 use winit_core::event_loop::proxy::EventLoopProxy as CoreEventLoopProxy;
 use winit_core::event_loop::EventLoopHandle;
-use winit_core::monitor::{Monitor as CoreMonitor, MonitorId};
-use winit_core::window::{Window as CoreWindow, WindowAttributes, WindowId};
+use winit_core::monitor::{Monitor as WinitMonitor, MonitorId};
+use winit_core::window::{Surface as WinitSurface, WindowAttributes, WindowId};
 
 use crate::monitor::Monitor;
 use crate::window::Window;
@@ -52,22 +52,22 @@ impl<T: Application + 'static> EventLoopHandle for WinitState<T> {
         self.windows.len()
     }
 
-    fn get_window(&self, window_id: WindowId) -> Option<&dyn CoreWindow> {
+    fn get_window(&self, window_id: WindowId) -> Option<&dyn WinitSurface> {
         let window = self.windows.get(&window_id)?;
 
         if window.last_configure.is_none() {
             return None;
         } else {
-            Some(window as &dyn CoreWindow)
+            Some(window as &dyn WinitSurface)
         }
     }
 
-    fn get_window_mut(&mut self, window_id: WindowId) -> Option<&mut dyn CoreWindow> {
+    fn get_window_mut(&mut self, window_id: WindowId) -> Option<&mut dyn WinitSurface> {
         let window = self.windows.get_mut(&window_id)?;
         if window.last_configure.is_none() {
             return None;
         } else {
-            Some(window as &mut dyn CoreWindow)
+            Some(window as &mut dyn WinitSurface)
         }
     }
 
@@ -75,15 +75,15 @@ impl<T: Application + 'static> EventLoopHandle for WinitState<T> {
         self.exit = true;
     }
 
-    fn get_monitor(&self, monitor_id: MonitorId) -> Option<&dyn CoreMonitor> {
+    fn get_monitor(&self, monitor_id: MonitorId) -> Option<&dyn WinitMonitor> {
         self.monitors
             .iter()
             .find(|monitor| monitor.id() == monitor_id)
-            .map(|monitor| monitor as &dyn CoreMonitor)
+            .map(|monitor| monitor as &dyn WinitMonitor)
     }
 
-    fn monitors(&self) -> Vec<&dyn CoreMonitor> {
-        self.monitors.iter().map(|monitor| monitor as &dyn CoreMonitor).collect()
+    fn monitors(&self) -> Vec<&dyn WinitMonitor> {
+        self.monitors.iter().map(|monitor| monitor as &dyn WinitMonitor).collect()
     }
 }
 

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -32,6 +32,7 @@ use winit_core::monitor::{Monitor as WinitMonitor, MonitorId};
 use winit_core::window::{Surface as WinitSurface, WindowAttributes, WindowId};
 
 use crate::monitor::Monitor;
+use crate::popup::Popup;
 use crate::toplevel::Toplevel;
 
 use crate::event_loop::{EventLoopProxy, RuntimeState};
@@ -46,6 +47,14 @@ impl<T: Application + 'static> EventLoopHandle for WinitState<T> {
         let window = Toplevel::new(self, attributes);
         let window_id = window.id();
         self.windows.insert(window_id, Window::Toplevel(window));
+        Ok(())
+    }
+
+    // TODO(jgcodes2020): can/should we ensure window type safety here?
+    fn create_popup(&mut self, parent: WindowId, attributes: &winit_core::window::PopupAttributes) -> Result<(), ()> {
+        let popup = Popup::new(self, parent, attributes)?;
+        let popup_id = popup.id();
+        self.windows.insert(popup_id, Window::Popup(popup));
         Ok(())
     }
 
@@ -86,6 +95,8 @@ impl<T: Application + 'static> EventLoopHandle for WinitState<T> {
     fn monitors(&self) -> Vec<&dyn WinitMonitor> {
         self.monitors.iter().map(|monitor| monitor as &dyn WinitMonitor).collect()
     }
+    
+    
 }
 
 impl<T: Application + 'static> HasDisplayHandle for WinitState<T> {
@@ -307,3 +318,4 @@ sctk::delegate_shm!(@<T: Application + 'static> RuntimeState<T>);
 sctk::delegate_compositor!(@<T: Application + 'static> RuntimeState<T>);
 sctk::delegate_xdg_shell!(@<T: Application + 'static> RuntimeState<T>);
 sctk::delegate_xdg_window!(@<T: Application + 'static> RuntimeState<T>);
+sctk::delegate_xdg_popup!(@<T: Application + 'static> RuntimeState<T>);

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -32,7 +32,7 @@ use winit_core::monitor::{Monitor as WinitMonitor, MonitorId};
 use winit_core::window::{Surface as WinitSurface, WindowAttributes, WindowId};
 
 use crate::monitor::Monitor;
-use crate::window::Window;
+use crate::toplevel::Toplevel;
 
 use crate::event_loop::{EventLoopProxy, RuntimeState};
 
@@ -42,7 +42,7 @@ impl<T: Application + 'static> EventLoopHandle for WinitState<T> {
     }
 
     fn create_window(&mut self, attributes: &WindowAttributes) -> Result<(), ()> {
-        let window = Window::new(self, attributes);
+        let window = Toplevel::new(self, attributes);
         let window_id = window.id();
         self.windows.insert(window_id, window);
         Ok(())
@@ -130,7 +130,7 @@ pub struct WinitState<T: Application + 'static> {
     /// Currently handled seats.
     pub seats: HashMap<ObjectId, ()>,
 
-    pub windows: HashMap<WindowId, Window<T>>,
+    pub windows: HashMap<WindowId, Toplevel<T>>,
 
     pub monitors: Vec<Monitor>,
 

--- a/winit-wayland/src/toplevel.rs
+++ b/winit-wayland/src/toplevel.rs
@@ -38,7 +38,7 @@ type WinitFrame<T> = sctk_adwaita::AdwaitaFrame<RuntimeState<T>>;
 #[cfg(not(feature = "sctk-adwaita"))]
 type WinitFrame = sctk::shell::xdg::fallback_frame::FallbackFrame<RuntimeState>;
 
-pub struct Window<T: Application + 'static> {
+pub struct Toplevel<T: Application + 'static> {
     /// The last received configure.
     pub last_configure: Option<WindowConfigure>,
 
@@ -98,7 +98,7 @@ pub struct Window<T: Application + 'static> {
     pub window: XdgWindow,
 }
 
-impl<T: Application + 'static> Window<T> {
+impl<T: Application + 'static> Toplevel<T> {
     pub fn new(winit: &mut WinitState<T>, attributes: &WindowAttributes) -> Self {
         let compositor = winit.compositor.clone();
         let surface = compositor.create_surface(&winit.queue_handle);
@@ -295,7 +295,7 @@ impl<T: Application + 'static> Window<T> {
     }
 }
 
-impl<T: Application + 'static> HasWindowHandle for Window<T> {
+impl<T: Application + 'static> HasWindowHandle for Toplevel<T> {
     fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
         let ptr = self.window.wl_surface().id().as_ptr();
         let handle = WaylandWindowHandle::new({
@@ -306,7 +306,7 @@ impl<T: Application + 'static> HasWindowHandle for Window<T> {
     }
 }
 
-impl<T: Application + 'static> WinitSurface for Window<T> {
+impl<T: Application + 'static> WinitSurface for Toplevel<T> {
     fn id(&self) -> WindowId {
         crate::make_wid(&self.window.wl_surface())
     }
@@ -330,9 +330,13 @@ impl<T: Application + 'static> WinitSurface for Window<T> {
     fn role_mut(&mut self) -> WindowRoleMut<'_> {
         WindowRoleMut::Toplevel(self)
     }
+    
+    fn create_subview(&self, attrs: WindowAttributes) -> Box<dyn winit_core::window::Subview> {
+        todo!()
+    }
 }
 
-impl<T: Application + 'static> WinitToplevel for Window<T> {
+impl<T: Application + 'static> WinitToplevel for Toplevel<T> {
     fn title(&self) -> &str {
         &self.title
     }
@@ -494,7 +498,7 @@ impl<T: Application + 'static> WindowHandler for RuntimeState<T> {
     }
 }
 
-unsafe impl<T: Application + 'static> HasRawWindowHandle05 for Window<T> {
+unsafe impl<T: Application + 'static> HasRawWindowHandle05 for Toplevel<T> {
     fn raw_window_handle(&self) -> raw_window_handle_05::RawWindowHandle {
         let mut window_handle = raw_window_handle_05::WaylandWindowHandle::empty();
         window_handle.surface = self.window.wl_surface().id().as_ptr() as *mut _;

--- a/winit-wayland/src/toplevel.rs
+++ b/winit-wayland/src/toplevel.rs
@@ -472,7 +472,7 @@ impl<T: Application + 'static> WindowHandler for RuntimeState<T> {
         };
 
         let user = self.user.as_mut().unwrap();
-        let initial_configue = window.last_configure.is_none();
+        let initial_configure = window.last_configure.is_none();
         window.last_configure = Some(configure);
 
         window.resize(new_size);
@@ -485,14 +485,14 @@ impl<T: Application + 'static> WindowHandler for RuntimeState<T> {
         // NOTE: we consider window as created when its initial configure arrives, until
         // then it's considered as not created and attempt to get it will result in
         // error.
-        if initial_configue {
+        if initial_configure {
             user.created(winit, window_id);
             user.scale_factor_changed(winit, window_id, scale_factor);
         }
 
         user.resized(winit, window_id, logical_to_physical_rounded(new_size, scale_factor));
 
-        if initial_configue {
+        if initial_configure {
             user.redraw_requested(winit, window_id);
         }
     }

--- a/winit-wayland/src/toplevel.rs
+++ b/winit-wayland/src/toplevel.rs
@@ -23,12 +23,16 @@ use wayland_client::{Connection, QueueHandle};
 use winit_core::application::Application;
 use winit_core::dpi::{LogicalSize, PhysicalSize, Size};
 use winit_core::monitor::MonitorId;
-use winit_core::window::{Surface as WinitSurface, Theme, Toplevel as WinitToplevel, WindowAttributes, WindowId, WindowRole, WindowRoleMut};
+use winit_core::window::{
+    Popup as WinitPopup, Surface as WinitSurface, Theme, Toplevel as WinitToplevel,
+    WindowAttributes, WindowId, WindowRole, WindowRoleMut,
+};
 
 use crate::event_loop::RuntimeState;
 use crate::logical_to_physical_rounded;
 use crate::monitor::Monitor;
 use crate::state::WinitState;
+use crate::window::Window;
 
 // Minimum window inner size.
 const MIN_WINDOW_SIZE: LogicalSize<u32> = LogicalSize::new(2, 1);
@@ -322,17 +326,13 @@ impl<T: Application + 'static> WinitSurface for Toplevel<T> {
     fn inner_size(&self) -> PhysicalSize<u32> {
         crate::logical_to_physical_rounded(self.size, self.scale_factor)
     }
-    
+
     fn role(&self) -> WindowRole<'_> {
         WindowRole::Toplevel(self)
     }
-    
+
     fn role_mut(&mut self) -> WindowRoleMut<'_> {
         WindowRoleMut::Toplevel(self)
-    }
-    
-    fn create_subview(&self, attrs: WindowAttributes) -> Box<dyn winit_core::window::Subview> {
-        todo!()
     }
 }
 
@@ -420,8 +420,8 @@ impl<T: Application + 'static> WindowHandler for RuntimeState<T> {
         let winit = &mut self.winit;
         let window_id = crate::make_wid(window.wl_surface());
         let window = match winit.windows.get_mut(&window_id) {
-            Some(window) => window,
-            None => return,
+            Some(Window::Toplevel(window)) => window,
+            _ => return,
         };
 
         let scale_factor = window.scale_factor;

--- a/winit-wayland/src/window.rs
+++ b/winit-wayland/src/window.rs
@@ -1,0 +1,94 @@
+use std::mem;
+
+use raw_window_handle::{HandleError, HasWindowHandle, WaylandWindowHandle, WindowHandle};
+use raw_window_handle_05::HasRawWindowHandle as HasRawWindowHandle05;
+
+use sctk::shell::xdg::window::WindowConfigure;
+use winit_core::{application::Application, window::Surface};
+
+use crate::{popup::Popup, toplevel::Toplevel};
+
+
+
+pub(crate) enum Window<T: Application + 'static> {
+    Toplevel(Toplevel<T>),
+    Popup(Popup<T>)
+}
+
+impl<T: Application + 'static> Window<T> {
+    pub(crate) fn configured(&self) -> bool {
+        match self {
+            Window::Toplevel(toplevel) => toplevel.configured(),
+            Window::Popup(popup) => popup.configured(),
+        }
+    }
+
+    pub(crate) fn take_redraw(&mut self) -> bool {
+        mem::take(match self {
+            Window::Toplevel(toplevel) => &mut toplevel.redraw,
+            Window::Popup(popup) => &mut popup.redraw,
+        })
+    }
+}
+
+impl<T: Application + 'static> Surface for Window<T> {
+    fn id(&self) -> winit_core::window::WindowId {
+        match self {
+            Window::Toplevel(toplevel) => toplevel.id(),
+            Window::Popup(popup) => popup.id(),
+        }
+    }
+
+    fn scale_factor(&self) -> f64 {
+        match self {
+            Window::Toplevel(toplevel) => toplevel.scale_factor(),
+            Window::Popup(popup) => popup.scale_factor(),
+        }
+    }
+
+    fn request_redraw(&mut self) {
+        match self {
+            Window::Toplevel(toplevel) => toplevel.request_redraw(),
+            Window::Popup(popup) => popup.request_redraw(),
+        }
+    }
+
+    fn inner_size(&self) -> winit_core::dpi::PhysicalSize<u32> {
+        match self {
+            Window::Toplevel(toplevel) => toplevel.inner_size(),
+            Window::Popup(popup) => popup.inner_size(),
+        }
+    }
+
+    fn role(&self) -> winit_core::window::WindowRole {
+        match self {
+            Window::Toplevel(toplevel) => toplevel.role(),
+            Window::Popup(popup) => popup.role(),
+        }
+    }
+
+    fn role_mut(&mut self) -> winit_core::window::WindowRoleMut {
+        match self {
+            Window::Toplevel(toplevel) => toplevel.role_mut(),
+            Window::Popup(popup) => popup.role_mut(),
+        }
+    }
+}
+
+impl<T: Application + 'static> HasWindowHandle for Window<T> {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        match self {
+            Window::Toplevel(toplevel) => toplevel.window_handle(),
+            Window::Popup(popup) => popup.window_handle(),
+        }
+    }
+}
+
+unsafe impl<T: Application + 'static> HasRawWindowHandle05 for Window<T> {
+    fn raw_window_handle(&self) -> raw_window_handle_05::RawWindowHandle {
+        match self {
+            Window::Toplevel(toplevel) => toplevel.raw_window_handle(),
+            Window::Popup(popup) => popup.raw_window_handle(),
+        }
+    }
+}


### PR DESCRIPTION
This PR separates `Window` into two traits: `Surface` and `Toplevel` (subtrait of `Surface`). `Surface` handles drawing- and event-related operations, while `Toplevel` handles things that only work for toplevel surfaces (maximizing/minimizing, etc.). 

This architecture allows us to create other subtraits of `Surface` to represent specific window roles. I have provided the `Subview` trait as a potential example of what this could be used for.